### PR TITLE
Add 3D Model Shop card to home page

### DIFF
--- a/src/components/ModelShopCard.astro
+++ b/src/components/ModelShopCard.astro
@@ -1,0 +1,44 @@
+---
+// 3D Model Shop promo card for the home page.
+// Casual blurb about on-demand character model extraction from any gacha game.
+// ~$19.99 per model, ordered through Discord (crypto payment).
+import { SITE } from '../consts';
+---
+
+<section class="model-shop-section">
+  <article class="model-shop-card">
+    <div class="model-shop-body">
+      <div class="model-shop-heading">
+        <h2 class="model-shop-title">3D Model Shop</h2>
+        <span class="model-shop-price">~$19</span>
+      </div>
+
+      <div class="model-shop-info">
+        <p class="model-shop-desc">
+          Looking for a model to see it without playing, or want the NSFW version for any game?
+          Hit me up on Discord.
+        </p>
+        <p class="model-shop-pay">Around 19 bucks, crypto only — we sort the details in Discord.</p>
+      </div>
+
+      <div class="model-shop-actions">
+        <a
+          href={SITE.SOCIAL.DISCORD}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="model-shop-cta"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path
+              d="M20.317 4.369A19.79 19.79 0 0 0 16.558 3c-.2.36-.43.84-.59 1.23a18.27 18.27 0 0 0-3.937 0C11.87 3.84 11.64 3.36 11.44 3a19.74 19.74 0 0 0-3.76 1.37C2.62 9.04 1.86 13.58 2.24 18.06a19.9 19.9 0 0 0 6.06 3.06c.49-.67.93-1.39 1.3-2.14-.71-.27-1.39-.6-2.04-.99.17-.13.34-.26.5-.4a14.18 14.18 0 0 0 11.88 0c.16.14.33.27.5.4-.65.39-1.33.72-2.04.99.37.75.81 1.47 1.3 2.14a19.84 19.84 0 0 0 6.06-3.06c.45-5.19-.77-9.69-3.74-13.7ZM9.68 15.33c-1.18 0-2.15-1.09-2.15-2.42 0-1.33.95-2.42 2.15-2.42 1.21 0 2.18 1.1 2.16 2.42 0 1.33-.95 2.42-2.16 2.42Zm4.64 0c-1.18 0-2.15-1.09-2.15-2.42 0-1.33.95-2.42 2.15-2.42 1.21 0 2.18 1.1 2.16 2.42 0 1.33-.95 2.42-2.16 2.42Z"></path>
+          </svg>
+          <span>DM me on Discord</span>
+        </a>
+      </div>
+    </div>
+  </article>
+</section>
+
+<style>
+  @import '../styles/components/model-shop.css';
+</style>

--- a/src/layouts/HomePageLayout.astro
+++ b/src/layouts/HomePageLayout.astro
@@ -3,6 +3,7 @@
 import HomeLayout from './HomeLayout.astro';
 import GeneralSEO from '../components/GeneralSEO.astro';
 import Analytics from '../components/Analytics.astro';
+import ModelShopCard from '../components/ModelShopCard.astro';
 
 export interface Props {
   title: string;
@@ -131,6 +132,9 @@ const { title, description } = Astro.props;
         </div>
       </div>
     </section>
+
+    <!-- 3D Model Shop promo section -->
+    <ModelShopCard />
   </main>
 
   <script>

--- a/src/styles/components/model-shop.css
+++ b/src/styles/components/model-shop.css
@@ -1,0 +1,163 @@
+/**
+ * ==========================================
+ * 3D MODEL SHOP CARD
+ * ==========================================
+ *
+ * Promo card for the home page advertising on-demand character model
+ * extraction from any gacha game. $19.99 per model, ordered via Discord.
+ *
+ * Visual language mirrors the Apps page cards (translucent white surface,
+ * subtle border, amber-tinted price pill) and the hero CTA button.
+ * Responsive down to 480px; honors prefers-reduced-motion.
+ */
+
+/* === SECTION WRAPPER === */
+/* Sits as a sibling section after the hero on the home page */
+.model-shop-section {
+  padding: 2rem 2rem 6rem 2rem;
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+/* === CARD === */
+.model-shop-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.model-shop-body {
+  padding: 1.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* === HEADING ROW === */
+.model-shop-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.model-shop-title {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  color: var(--amber-glow);
+  line-height: var(--leading-tight);
+}
+
+/* Price pill — mirrors .app-tag from apps.css */
+.model-shop-price {
+  display: inline-block;
+  background: rgba(255, 183, 77, 0.1);
+  color: var(--amber-glow);
+  font-family: var(--font-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+/* === COPY === */
+.model-shop-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.model-shop-desc {
+  font-family: var(--font-primary);
+  font-size: var(--text-base);
+  font-weight: var(--font-normal);
+  color: var(--text-inverse);
+  opacity: 0.75;
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+.model-shop-note {
+  font-family: var(--font-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--text-inverse);
+  opacity: 0.6;
+  margin: 0;
+}
+
+/* === ACTIONS === */
+.model-shop-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+/* Discord CTA — mirrors the hero .cta-button look */
+.model-shop-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 0.9rem 1.75rem;
+  background: rgba(255, 183, 77, 0.9);
+  border: 2px solid rgba(255, 183, 77, 1);
+  border-radius: 12px;
+  color: #1a1a1a;
+  text-decoration: none;
+  font-family: var(--font-primary);
+  font-weight: var(--font-bold);
+  font-size: var(--text-base);
+  min-height: 48px;
+  min-width: 44px;
+  cursor: pointer;
+}
+
+.model-shop-cta svg {
+  color: #1a1a1a;
+}
+
+.model-shop-pay {
+  font-family: var(--font-primary);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+}
+
+/* === RESPONSIVE === */
+@media (max-width: 768px) {
+  .model-shop-section {
+    padding: 1rem 1rem 4rem 1rem;
+  }
+
+  .model-shop-body {
+    padding: 1.25rem 1.25rem;
+  }
+
+  .model-shop-title {
+    font-size: var(--text-xl);
+  }
+
+  .model-shop-cta {
+    width: 100%;
+    max-width: 320px;
+  }
+}
+
+@media (max-width: 480px) {
+  .model-shop-heading {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}
+
+/* === MOTION PREFERENCE === */
+/* No animations on this card — nothing to disable */


### PR DESCRIPTION
Adds a new promo section to the home page advertising on-demand character model extraction from any gacha game.

**What's included:**
- New `ModelShopCard` component (`src/components/ModelShopCard.astro`)
- Scoped styling (`src/styles/components/model-shop.css`) matching the existing apps-page card visual language
- Wired into `HomePageLayout.astro` as a section below the hero

**Details:**
- ~$19 per model, crypto only
- Ordering handled through Discord (links to `SITE.SOCIAL.DISCORD`)
- No hover effects, casual copy, text-only (no preview image)
- Responsive (768px / 480px breakpoints)